### PR TITLE
Update version of forever-monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clone": "^1.0.2",
     "colors": "~0.6.2",
     "flatiron": "~0.4.2",
-    "forever-monitor": "~1.6.0",
+    "forever-monitor": "~1.7.0",
     "nconf": "~0.6.9",
     "nssocket": "~0.5.1",
     "object-assign": "^3.0.0",


### PR DESCRIPTION
The current version of forever-monitor prompts this nsp warning: https://nodesecurity.io/advisories/118.
